### PR TITLE
feat: Repo license check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,6 @@ dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
- "actix-tls",
  "actix-utils",
  "ahash 0.8.3",
  "base64 0.21.2",
@@ -123,24 +122,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "actix-tls"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fde0cf292f7cdc7f070803cb9a0d45c018441321a78b1042ffbbb81ec333297"
-dependencies = [
- "actix-codec",
- "actix-rt",
- "actix-service",
- "actix-utils",
- "futures-core",
- "log",
- "pin-project-lite",
- "tokio-rustls 0.23.4",
- "tokio-util",
- "webpki-roots 0.22.6",
-]
-
-[[package]]
 name = "actix-utils"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,7 +144,6 @@ dependencies = [
  "actix-rt",
  "actix-server",
  "actix-service",
- "actix-tls",
  "actix-utils",
  "actix-web-codegen",
  "ahash 0.7.6",
@@ -1352,9 +1332,9 @@ dependencies = [
  "futures-util",
  "http",
  "hyper",
- "rustls 0.21.5",
+ "rustls",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -2256,14 +2236,14 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.5",
+ "rustls",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
  "tokio-util",
  "tower-service",
  "url",
@@ -2322,18 +2302,6 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "rustls"
-version = "0.20.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
-dependencies = [
- "log",
- "ring",
- "sct",
- "webpki",
 ]
 
 [[package]]
@@ -2823,22 +2791,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
-dependencies = [
- "rustls 0.20.8",
- "tokio",
- "webpki",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.5",
+ "rustls",
  "tokio",
 ]
 
@@ -2891,7 +2848,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-pemfile",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",
@@ -3051,7 +3008,7 @@ dependencies = [
  "base64 0.21.2",
  "log",
  "once_cell",
- "rustls 0.21.5",
+ "rustls",
  "rustls-webpki 0.100.1",
  "url",
  "webpki-roots 0.23.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/open-sauced/repo-query"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix-web = { version = "4", features = ["rustls"] }
+actix-web = "4"
 anyhow = "1"
 async-trait = "0.1"
 dotenv = "0.15"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 </div>
 
 ## 🔎 The Project
-RepoQuery is an early-beta project, that uses recursive [OpenAI function calling](https://platform.openai.com/docs/api-reference/chat/create#chat/create-functions) paired with semantic search using [All-MiniLM-L6-V2](https://huggingface.co/rawsh/multi-qa-MiniLM-distill-onnx-L6-cos-v1/blob/main/onnx/model_quantized.onnx) to index and answer user queries about public GitHub repositories.
+RepoQuery is an early-beta project, that uses recursive [OpenAI function calling](https://platform.openai.com/docs/api-reference/chat/create#chat/create-functions) paired with semantic search using [multi-qa-MiniLM-L6-cos-v1](https://huggingface.co/rawsh/multi-qa-MiniLM-distill-onnx-L6-cos-v1/blob/main/onnx/model_quantized.onnx) to index and answer user queries about public GitHub repositories.
 
 ##  📬 Service Endpoints
 

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -278,7 +278,7 @@ mod tests {
         let is_allowed = is_indexing_allowed(&repository).await.unwrap_or_default();
         assert_eq!(is_allowed, true);
 
-        //Imermissible
+        //Impermissible
         let repository = Repository {
             owner: "open-sauced".to_string(),
             name: "guestbook".to_string(),

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -285,7 +285,6 @@ mod tests {
         };
 
         let license_info = fetch_license_info(&repository).await.unwrap_or_default();
-        dbg!(&license_info);
         assert_eq!(license_info.permissible, true);
 
         //Permissible

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -3,13 +3,13 @@ pub mod events;
 
 use crate::constants::SSE_CHANNEL_BUFFER_SIZE;
 use crate::conversation::{Conversation, Query};
-use crate::github::fetch_repo_files;
+use crate::github::{fetch_repo_files, is_indexing_allowed};
 use crate::routes::events::QueryEvent;
 use crate::{db::RepositoryEmbeddingsDB, github::Repository};
 use actix_web::web::Query as ActixQuery;
 use actix_web::HttpResponse;
 use actix_web::{
-    error::ErrorNotFound,
+    error::{ErrorBadRequest, ErrorForbidden, ErrorNotFound},
     get, post,
     web::{self, Json},
     Responder, Result,
@@ -26,7 +26,11 @@ async fn embeddings(
     data: Json<Repository>,
     db: web::Data<Arc<QdrantDB>>,
     model: web::Data<Arc<Onnx>>,
-) -> impl Responder {
+) -> Result<impl Responder> {
+    if !is_indexing_allowed(&data).await.map_err(ErrorBadRequest)? {
+        return Err(ErrorForbidden("Impermissible repository license"));
+    }
+
     let (sender, rx) = sse::channel(SSE_CHANNEL_BUFFER_SIZE);
 
     actix_rt::spawn(async move {
@@ -58,7 +62,7 @@ async fn embeddings(
         }
     });
 
-    rx
+    Ok(rx)
 }
 
 #[post("/query")]


### PR DESCRIPTION
## Description
This PR updates the dependencies in the Cargo.lock file. It removes the `actix-tls` package and updates the versions of `actix-utils`, `rustls`, `tokio-rustls`, and `tokio` packages. The changes in the Cargo.toml file include removing the feature flag for `rustls` in the `actix-web` package. Additionally, this PR introduces a new function `is_indexing_allowed` in the `github/mod.rs` file to check if indexing is allowed based on the repository's license. The function is used in the `embeddings` route in the `routes/mod.rs` file to validate the repository's license before processing the request. The PR also includes tests for the new function.

_Generated using [OpenSauced](https://opensauced.ai/)._

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
Resolves #7. 

## Mobile & Desktop Screenshots/Recordings

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed