### PR TITLE
feat: Upgrade to openai-api-rs 2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1711,9 +1711,9 @@ dependencies = [
 
 [[package]]
 name = "openai-api-rs"
-version = "1.0.4"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeab072070ad2fdba1b1f1a7de48d8a499871e5777bc855fcf81e9f8b2ef7a40"
+checksum = "3696225585180dd710afc91eb91048464e8ea7b4154f30f33fdea5393a9289ea"
 dependencies = [
  "minreq",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rayon = "1"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "json"] }
 serde = "1"
 tokenizers = "0.14"
-openai-api-rs = "1.0"
+openai-api-rs = "2.0"
 zip = "0.6"
 rust-fuzzy-search = "0.1"
 text-splitter = "0.4"

--- a/src/conversation/mod.rs
+++ b/src/conversation/mod.rs
@@ -93,7 +93,8 @@ impl<D: RepositoryEmbeddingsDB, M: EmbeddingsModel> Conversation<D, M> {
         #[allow(unused_labels)]
         'conversation: loop {
             //Generate a request with the message history and functions
-            let request = generate_completion_request(self.messages.clone(), FunctionCallType::Auto);
+            let request =
+                generate_completion_request(self.messages.clone(), FunctionCallType::Auto);
 
             match self.send_request(request) {
                 Ok(response) => {

--- a/src/conversation/prompts.rs
+++ b/src/conversation/prompts.rs
@@ -1,6 +1,6 @@
 use openai_api_rs::v1::chat_completion::{
-    ChatCompletionMessage, ChatCompletionRequest, Function as F, FunctionParameters,
-    JSONSchemaDefine, JSONSchemaType, FunctionCallType,
+    ChatCompletionMessage, ChatCompletionRequest, Function as F, FunctionCallType,
+    FunctionParameters, JSONSchemaDefine, JSONSchemaType,
 };
 use std::collections::HashMap;
 
@@ -17,23 +17,10 @@ pub fn generate_completion_request(
     messages: Vec<ChatCompletionMessage>,
     function_call: FunctionCallType,
 ) -> ChatCompletionRequest {
-
-    ChatCompletionRequest {
-        model: CHAT_COMPLETION_MODEL.into(),
-        messages,
-        functions: Some(functions()),
-        function_call: Some(function_call),
-        temperature: Some(CHAT_COMPLETION_TEMPERATURE),
-        top_p: None,
-        n: None,
-        stream: None,
-        stop: None,
-        max_tokens: None,
-        presence_penalty: None,
-        frequency_penalty: None,
-        logit_bias: None,
-        user: None,
-    }
+    ChatCompletionRequest::new(CHAT_COMPLETION_MODEL.to_string(), messages)
+        .functions(functions())
+        .function_call(function_call)
+        .temperature(CHAT_COMPLETION_TEMPERATURE)
 }
 
 pub fn functions() -> Vec<F> {


### PR DESCRIPTION
## Description

The types in openai-api-rs didn't change but this uses the `new` methods for the `ChatCompletionRequest` implementations / types

Once we get this in, should be able to cut a new release to `beta` and get this deployed.

Also ran `make lint` which caught a few linting errors

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Closes https://github.com/open-sauced/repo-query/pull/57

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
